### PR TITLE
fix: check socket writable before write

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -79,7 +79,7 @@ class Connection extends Base {
     this._socket = this._socket || net.createConnection({ host, port });
     this._socket.on('connect', this._onConnect.bind(this));
     this._socket.on('data', data => this.read(data));
-    this._protocol.on('data', data => this._socket.write(data));
+    this._protocol.on('data', data => this._socket.writable && this._socket.write(data));
     this._protocol.on('packet', this._onPacket.bind(this));
     this._protocol.on('error', this._onError.bind(this));
     this._socket.on('error', this._onError.bind(this));
@@ -141,7 +141,6 @@ class Connection extends Base {
 
   get localAddress() {
     return this._socket && this._socket.localAddress;
-
   }
 
   get localPort() {


### PR DESCRIPTION
当客户端连接关闭后，可能刚好需要响应服务端发过来的心跳包，需要判断socket的是否writable